### PR TITLE
Breaking: Upgrade to Hapi 18 and hapi scoped packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2019-10-7
+### BREAKING CHANGE
+- Upgrade Hapi to v18
+    - **`@hapi/hapi` v18.3.2 or newer now required**
+    - If you are still on Hapi v17, please continue to use v1.0.0
+
+### Changed
+- Use the new `@hapi` scoped packages for Vision and Joi
+
+## [1.0.0] - 2019-04-19
+### Initial release

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 *   [Further Reading](#further-reading)
 
 ## Introduction
-A Hapi.js plugin that works with the [catalyst-server](https://github.com/homeaway/catalyst-server) to aid in server-side rendering using Handlebars and React. It allows you to relate a Handlebars template and a React component to a route. This route will automatically be registered with the server and will decorate `request.pre.component` with the react component and the `request.pre.template` with the template.  It will also register visions and server views with Handlebars rendering for the page scaffolding.
+A Hapi.js plugin that works with the [catalyst-server](https://github.com/homeaway/catalyst-server) to aid in server-side rendering using Handlebars and React. It allows you to relate a Handlebars template and a React component to a route. This route will automatically be registered with the server and will decorate `request.pre.component` with the react component and the `request.pre.template` with the template.  It will also register @hapi/vision and server views with Handlebars rendering for the page scaffolding.
 
 ## Usage
 
@@ -67,7 +67,7 @@ module.exports = {
 | options | <code>object</code> | Overriding options |
 | options.routes | <code>array</code> | A list of [route](###route) objects to register on server. |
 | [options.viewsOptions] | <code>object</code> | Options to add to (or override) when on `server.views` method is called for adding things like partials ,, layouts, helpers and others. |
-| [options.visionOptions] | <code>object</code> | Proxy for options when registering [Vision](https://www.npmjs.com/package/vision). |
+| [options.visionOptions] | <code>object</code> | Proxy for options when registering [@hapi/vision](https://www.npmjs.com/package/@hapi/vision). |
 | [options.resolveAssetHelper] | <code>object</code> | A Handlebars helper to help resolve static assets, as in publishing to a CDN. |
 | options.resolveAssetHelper.name | <code>string</code> | Name of helper. |
 | options.resolveAssetHelper.helper | <code>function</code> | Helper function. |

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 const Handlebars = require('handlebars')
-const Vision = require('vision')
+const Vision = require('@hapi/vision')
 const Path = require('path')
 const debug = require('debug')('catalyst-render')
 const { name, version } = require('../package.json')
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 const internals = {
   schema: Joi.object().keys({
@@ -42,7 +42,7 @@ const internals = {
 }
 
 async function register (server, options) {
-  const { routes, viewsOptions, visionOptions, resolveAssetHelper } = await Joi.validate(options, internals.schema)
+  const { routes, viewsOptions, visionOptions, resolveAssetHelper } = await internals.schema.validateAsync(options)
   const isProd = (process.env.NODE_ENV || 'development').toLocaleLowerCase() === 'production'
   const relativeTo = Path.join(process.cwd(), isProd ? 'build' : 'src', 'server')
   const defaultViewsOptions = { relativeTo: relativeTo, engines: { hbs: Handlebars } }

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+const Path = require('path')
 const Handlebars = require('handlebars')
 const Vision = require('@hapi/vision')
-const Path = require('path')
+const Joi = require('@hapi/joi')
 const debug = require('debug')('catalyst-render')
 const { name, version } = require('../package.json')
-const Joi = require('@hapi/joi')
 
 const internals = {
   schema: Joi.object().keys({

--- a/package.json
+++ b/package.json
@@ -44,16 +44,16 @@
   ],
   "license": "Apache-2.0",
   "peerDependencies": {
-    "hapi": ">=17.0.0"
+    "@hapi/hapi": ">=18.3.2"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "handlebars": "^4.0.12",
-    "joi": "^14.3.1",
-    "vision": "^5.4.4"
+    "handlebars": "^4.4.2",
+    "@hapi/joi": "^16.1.7",
+    "@hapi/vision": "^5.5.4"
   },
   "devDependencies": {
-    "hapi": "^17.8.4",
+    "@hapi/hapi": "^18.3.2",
     "nyc": "^13.2.0",
     "standard": "^12.0.1",
     "tap-spec": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@hapi/hapi": ">=18.3.2"
+    "@hapi/hapi": ">=17.9.0"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,5 @@
 const Tape = require('tape')
-const Hapi = require('hapi')
+const Hapi = require('@hapi/hapi')
 const Plugin = require('../lib')
 
 Tape('catalyst-render (bad init)', async (t) => {
@@ -21,7 +21,7 @@ Tape('catalyst-render (init with resolveAssetHelper)', async (t) => {
   }
   const server = {
     register ({ plugin }, options) {
-      t.equals(plugin.pkg.name, 'vision', 'Vision passed')
+      t.equals(plugin.pkg.name, '@hapi/vision', 'Vision passed')
       t.notOk(options, 'undefined options')
     },
     views (options) {
@@ -49,7 +49,7 @@ Tape('catalyst-render (configuration/dev/default)', async (t) => {
   }
   const server = {
     register ({ plugin }, options) {
-      t.equals(plugin.pkg.name, 'vision', 'Vision passed')
+      t.equals(plugin.pkg.name, '@hapi/vision', 'Vision passed')
       t.notOk(options, 'undefined options')
     },
     views (options) {
@@ -71,7 +71,7 @@ Tape('catalyst-render (configuration/prod)', async (t) => {
   }
   const server = {
     register ({ plugin }, options) {
-      t.equals(plugin.pkg.name, 'vision', 'Vision passed')
+      t.equals(plugin.pkg.name, '@hapi/vision', 'Vision passed')
       t.notOk(options, 'undefined options')
     },
     views (options) {
@@ -97,7 +97,7 @@ Tape('catalyst-render (views and vision options)', async (t) => {
   }
   const server = {
     register ({ plugin }, options) {
-      t.equals(plugin.pkg.name, 'vision', 'Vision passed')
+      t.equals(plugin.pkg.name, '@hapi/vision', 'Vision passed')
       t.ok(options, 'options passed')
       t.ok(options.isCached, 'isCached passed')
     },


### PR DESCRIPTION
Upgrade Hapi to v18
    - **`@hapi/hapi` v18.3.2 or newer now required**
    - Use the new `@hapi` scoped packages for Vision and Joi

Update `CHANGELOG.md`
Update `README.MD`

@tuckbick I left the peer dependecy for hapi to be `>=18.3.2` instead of the latest of `18.4.0` since that version [drops node 8](url) support which would necessitate updating the `engines` property in `package.json`, yes?

Also, I noticed `catalyst-server` is still using [Joi v15](https://github.com/homeaway/catalyst-server/blob/master/package.json#L59). I've [submitted a PR](https://github.com/homeaway/catalyst-server/pull/3) to upgrade to `v16.x` to be consistent with this PR.